### PR TITLE
✨ feat: add prediction endpoint to AI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ AI_SERVICE_URL="http://localhost:8001"
 JWT_SECRET="your-super-secret-jwt-key-change-in-production"
 ```
 
+### AI Service Endpoints
+
+| Endpoint   | Method | Description                      |
+| ---------- | ------ | -------------------------------- |
+| `/health`  | `GET`  | Health check for the AI service  |
+| `/analyze` | `POST` | Analyze entries and meals        |
+| `/predict` | `POST` | Predict your next bowel movement |
+
 ### Production Build
 
 ```bash


### PR DESCRIPTION
## Summary
- add `/predict` endpoint to AI service for forecasting next bowel movement
- document new AI service endpoints in README
- test prediction logic

## Testing
- `pnpm --dir frontend exec vitest run`
- `pnpm --dir backend exec jest --passWithNoTests`
- `cd ai-service && python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e654bc00883208e4a3f68bb2798db