### PR TITLE
🚀 feat: add summary endpoint to AI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ We encrypt your brown notes and hide them away. Nobody's reading your logs excep
 - Meal correlation analysis
 - Health recommendations
 - Risk factor identification
+- Cached summary endpoint for quick retrieval
 
 ### Photo Documentation
 

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -10,3 +10,4 @@ python-multipart==0.0.20
 redis==6.2.0
 scikit-learn==1.7.0
 uvicorn[standard]==0.34.3
+fakeredis==2.29.0


### PR DESCRIPTION
## Summary
- add cached summary endpoint to ai-service
- include fakeredis for tests
- test summary endpoint
- document feature in README

## Testing
- `pnpm --filter ./frontend... exec vitest run`
- `pnpm --filter ./backend... exec jest --passWithNoTests`
- `cd ai-service && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e654bc00883208e4a3f68bb2798db