### PR TITLE
🧪 test: add basic frontend and backend coverage

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['standard-with-typescript'],
+  parserOptions: {
+    project: './tsconfig.json'
+  }
+}

--- a/backend/src/__mocks__/@prisma/client.ts
+++ b/backend/src/__mocks__/@prisma/client.ts
@@ -1,0 +1,11 @@
+export class PrismaClient {
+  user = {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn()
+  }
+  userAuth = {
+    findUnique: jest.fn(),
+    update: jest.fn()
+  }
+}

--- a/backend/src/__tests__/app.test.ts
+++ b/backend/src/__tests__/app.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest'
+import express from 'express'
+
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test'
+process.env.JWT_SECRET = 'test-secret'
+process.env.JWT_EXPIRES_IN = '1d'
+
+const prismaMock = {
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn()
+  },
+  userAuth: {
+    findUnique: jest.fn(),
+    update: jest.fn()
+  }
+}
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => prismaMock)
+}))
+jest.mock('bcryptjs', () => ({ compare: jest.fn(), hash: jest.fn() }))
+jest.mock('jsonwebtoken', () => ({ sign: jest.fn() }))
+
+import { authRoutes } from '../routes/auth'
+import { errorHandler } from '../middleware/errorHandler'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const createApp = () => {
+  const app = express()
+  app.use(express.json())
+  const healthHandler: express.RequestHandler = (_req, res) => {
+    res.json({ status: 'OK' })
+  }
+  app.get('/health', healthHandler)
+  app.use('/api/auth', authRoutes)
+  app.use(errorHandler)
+  return app
+}
+
+describe('health endpoint', () => {
+  it('responds with status OK', async () => {
+    const app = createApp()
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('OK')
+  })
+})
+
+describe('POST /api/auth/login', () => {
+  it('returns 401 for invalid credentials', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null)
+    const app = createApp()
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'a@b.com', password: 'secret' })
+    expect(res.status).toBe(401)
+    expect(res.body.error).toBe('Invalid credentials')
+  })
+
+  it('logs in successfully', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: '1',
+      email: 'a@b.com',
+      name: 'Test',
+      auth: { password: 'hashed' }
+    })
+    ;(bcrypt.compare as jest.Mock).mockResolvedValue(true)
+    prismaMock.userAuth.update.mockResolvedValue({})
+    ;(jwt.sign as jest.Mock).mockReturnValue('token')
+
+    const app = createApp()
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'a@b.com', password: 'secret' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.token).toBe('token')
+    expect(prismaMock.userAuth.update).toHaveBeenCalled()
+  })
+})

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "env": { "browser": true, "es2022": true, "node": true }
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,10 @@
+export default {
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  env: { browser: true, es2022: true, node: true },
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module"
+  }
+};

--- a/frontend/src/components/Logo.test.tsx
+++ b/frontend/src/components/Logo.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Logo from "./Logo";
+
+describe("Logo component", () => {
+  it("renders with default size", () => {
+    const { container } = render(<Logo />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("width")).toBe("24");
+    expect(svg?.getAttribute("height")).toBe("24");
+  });
+
+  it("applies custom size and class", () => {
+    const { container } = render(<Logo size={48} className="custom" />);
+    const svg = container.querySelector("svg") as SVGElement;
+    expect(svg.getAttribute("width")).toBe("48");
+    expect(svg.classList.contains("custom")).toBe(true);
+  });
+});

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAuthStore } from "./authStore";
+
+const userResponse = {
+  token: "tok",
+  user: { id: "1", email: "a@b.com", name: "Tester" }
+};
+
+describe("authStore", () => {
+  afterEach(() => {
+    useAuthStore.getState().logout();
+    vi.restoreAllMocks();
+  });
+
+  it("logs in and updates state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(userResponse)
+        })
+      ) as any
+    );
+
+    await useAuthStore.getState().login("a@b.com", "secret");
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.user?.email).toBe("a@b.com");
+    expect(state.token).toBe("tok");
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest tests for Logo component and auth store
- add Jest/Supertest tests for auth routes and health
- add minimal ESLint config for packages

## Testing
- `pnpm run -r test`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e655efd248320aae93b0deaac1499