### PR TITLE
🧪 test: add frontend and backend tests

### DIFF
--- a/backend/src/__tests__/health.test.ts
+++ b/backend/src/__tests__/health.test.ts
@@ -1,0 +1,17 @@
+process.env.NODE_ENV = 'test'
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/test'
+
+import request from 'supertest'
+
+jest.mock('@prisma/client', () => ({ PrismaClient: jest.fn(() => ({})) }))
+
+import app from '../index'
+
+describe('GET /health', () => {
+  it('should return ok status', async () => {
+    const res = await request(app).get('/health')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('status', 'OK')
+    expect(res.body).toHaveProperty('timestamp')
+  })
+})

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -68,17 +68,23 @@ app.use((_req, res, next) => {
 // Error handling
 app.use(errorHandler)
 
-const server = app.listen(config.port, () => {
-  console.log(`🚽 Poo Tracker API running on port ${config.port}`)
-  console.log(`📊 Health check available at http://localhost:${config.port}/health`)
-})
+let server: import('http').Server | null = null
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  console.log('SIGTERM received, shutting down gracefully')
-  server.close(() => {
-    console.log('Process terminated')
+if (config.nodeEnv !== 'test') {
+  server = app.listen(config.port, () => {
+    console.log(`🚽 Poo Tracker API running on port ${config.port}`)
+    console.log(`📊 Health check available at http://localhost:${config.port}/health`)
   })
-})
+
+  // Graceful shutdown
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM received, shutting down gracefully')
+    server?.close(() => {
+      console.log('Process terminated')
+    })
+  })
+}
+
+export { server }
 
 export default app

--- a/frontend/src/components/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import { ProtectedRoute } from "./ProtectedRoute";
+
+const useAuthStoreMock = vi.fn();
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: () => useAuthStoreMock()
+}));
+
+describe("ProtectedRoute", () => {
+  it("redirects to login when not authenticated", () => {
+    useAuthStoreMock.mockReturnValue({ isAuthenticated: false });
+    render(
+      <MemoryRouter initialEntries={["/secret"]}>
+        <Routes>
+          <Route
+            path="/secret"
+            element={
+              <ProtectedRoute>
+                <div>secret</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/login page/i)).toBeInTheDocument();
+  });
+
+  it("renders children when authenticated", () => {
+    useAuthStoreMock.mockReturnValue({ isAuthenticated: true });
+    render(
+      <MemoryRouter initialEntries={["/secret"]}>
+        <Routes>
+          <Route
+            path="/secret"
+            element={
+              <ProtectedRoute>
+                <div>secret</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/secret/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import { HomePage } from "./HomePage";
+
+const useAuthStoreMock = vi.fn();
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: () => useAuthStoreMock()
+}));
+
+describe("HomePage", () => {
+  it("shows call to action when not authenticated", () => {
+    useAuthStoreMock.mockReturnValue({ isAuthenticated: false });
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Get Started/i)).toBeInTheDocument();
+  });
+
+  it("shows dashboard link when authenticated", () => {
+    useAuthStoreMock.mockReturnValue({ isAuthenticated: true });
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Go to Dashboard/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent backend server from starting during tests
- add backend health endpoint test
- add frontend tests for home page and protected routes

## Testing
- `pnpm --dir frontend exec vitest run`
- `pnpm --dir backend exec jest`
- `cd ai-service && python -m pytest`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684e655efd248320aae93b0deaac1499