### PR TITLE
🧪 test: improve repo coverage

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -5,5 +5,10 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/index.ts'],
   coverageDirectory: 'coverage',
-  coverageReporters: ['text', 'lcov', 'html']
+  coverageReporters: ['text', 'lcov', 'html'],
+  globals: {
+    'ts-jest': {
+      diagnostics: false
+    }
+  }
 }

--- a/backend/src/__tests__/app.test.ts
+++ b/backend/src/__tests__/app.test.ts
@@ -1,0 +1,68 @@
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test'
+process.env.JWT_SECRET = 'testsecret'
+process.env.NODE_ENV = 'test'
+import request from 'supertest'
+import app from '../index'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+jest.mock('@prisma/client', () => {
+  const mPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn()
+    },
+    userAuth: {
+      findUnique: jest.fn(),
+      update: jest.fn()
+    },
+    entry: {
+      count: jest.fn(),
+      groupBy: jest.fn(),
+      findMany: jest.fn(),
+      aggregate: jest.fn()
+    }
+  }
+  return { PrismaClient: jest.fn(() => mPrisma), __esModule: true, default: mPrisma }
+})
+
+const { PrismaClient } = jest.requireMock('@prisma/client') as any
+const prisma = new PrismaClient()
+
+describe('API Endpoints', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('GET /health should return ok', async () => {
+    const res = await request(app).get('/health')
+    expect(res.statusCode).toBe(200)
+    expect(res.body.status).toBeDefined()
+  })
+
+  it('POST /api/auth/login success', async () => {
+    prisma.user.findUnique.mockResolvedValue({
+      id: '1',
+      email: 'test@example.com',
+      name: 'Tester',
+      auth: { password: 'hashed' }
+    })
+    prisma.userAuth.update.mockResolvedValue({})
+    jest.spyOn(bcrypt as any, 'compare').mockResolvedValue(true as any)
+    jest.spyOn(jwt, 'sign').mockReturnValue('token123' as any)
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@example.com', password: 'password' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body.token).toBe('token123')
+    expect(prisma.user.findUnique).toHaveBeenCalled()
+  })
+
+  it('GET /api/entries requires auth', async () => {
+    const res = await request(app).get('/api/entries')
+    expect(res.statusCode).toBe(401)
+  })
+})

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -68,17 +68,23 @@ app.use((_req, res, next) => {
 // Error handling
 app.use(errorHandler)
 
-const server = app.listen(config.port, () => {
-  console.log(`🚽 Poo Tracker API running on port ${config.port}`)
-  console.log(`📊 Health check available at http://localhost:${config.port}/health`)
-})
+let server: ReturnType<typeof app.listen> | undefined
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  console.log('SIGTERM received, shutting down gracefully')
-  server.close(() => {
-    console.log('Process terminated')
+if (process.env.NODE_ENV !== 'test') {
+  server = app.listen(config.port, () => {
+    console.log(`🚽 Poo Tracker API running on port ${config.port}`)
+    console.log(`📊 Health check available at http://localhost:${config.port}/health`)
   })
-})
+
+  // Graceful shutdown
+  process.on('SIGTERM', () => {
+    console.log('SIGTERM received, shutting down gracefully')
+    server?.close(() => {
+      console.log('Process terminated')
+    })
+  })
+}
+
+export { server }
 
 export default app

--- a/frontend/src/AuthStore.test.ts
+++ b/frontend/src/AuthStore.test.ts
@@ -1,0 +1,44 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { useAuthStore } from "./stores/authStore";
+
+const originalFetch = global.fetch;
+
+describe("useAuthStore", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    useAuthStore.setState({ user: null, token: null, isAuthenticated: false });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("login stores token and user", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          user: { id: "1", email: "test@example.com" },
+          token: "tok"
+        })
+    });
+
+    await useAuthStore.getState().login("test@example.com", "password");
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.token).toBe("tok");
+    expect(state.user?.email).toBe("test@example.com");
+  });
+
+  it("login throws on failure", async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "fail" })
+    });
+
+    await expect(
+      useAuthStore.getState().login("bad@example.com", "wrong")
+    ).rejects.toThrow("fail");
+  });
+});

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { useAuthStore } from "../stores/authStore";
+import { Navbar } from "./Navbar";
+import { vi, describe, it, expect } from "vitest";
+
+describe("Navbar", () => {
+  it("shows login link when unauthenticated", () => {
+    useAuthStore.setState({ user: null, token: null, isAuthenticated: false });
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/login/i)).toBeInTheDocument();
+  });
+
+  it("shows dashboard link when authenticated", () => {
+    useAuthStore.setState({
+      user: { id: "1", email: "a@b.c", name: "A" },
+      token: "tok",
+      isAuthenticated: true,
+      login: useAuthStore.getState().login,
+      setAuth: useAuthStore.getState().setAuth,
+      logout: vi.fn()
+    });
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    );
+    expect(screen.getAllByText(/dashboard/i)[0]).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent server from starting when running tests
- disable ts-jest diagnostics and set up Prisma mocks
- add backend API tests
- add vitest store and component tests

## Testing
- `pnpm run --filter ./backend test --coverage`
- `pnpm run --filter ./frontend test -- --coverage`
- `cd ai-service && python -m pytest -q`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e655efd248320aae93b0deaac1499