### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/backend/src/routes/uploads.ts
+++ b/backend/src/routes/uploads.ts
@@ -101,6 +101,11 @@ router.delete(
         res.status(400).json({ error: 'Invalid filename' })
         return
       }
+      // Additional sanitization to prevent path traversal
+      if (filename.includes('..') || filename.startsWith('/')) {
+        res.status(400).json({ error: 'Invalid filename' })
+        return
+      }
 
       const imageProcessor = ImageProcessingFactory.getInstance()
       await imageProcessor.deleteImage(filename)

--- a/backend/src/services/ImageProcessingService.ts
+++ b/backend/src/services/ImageProcessingService.ts
@@ -85,7 +85,10 @@ export class SharpImageProcessingService implements ImageProcessingService {
   }
 
   async deleteImage(filename: string): Promise<void> {
-    const filePath = path.join(this.uploadDir, filename)
+    const filePath = path.resolve(this.uploadDir, filename)
+    if (!filePath.startsWith(this.uploadDir)) {
+      throw new Error(`Invalid file path: ${filename}`)
+    }
     try {
       await fs.unlink(filePath)
     } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/kjanat/poo-tracker/security/code-scanning/11](https://github.com/kjanat/poo-tracker/security/code-scanning/11)

To fix the issue, we need to ensure that the constructed file path is contained within the `uploadDir`. This can be achieved by normalizing the path using `path.resolve` and verifying that the resolved path starts with `uploadDir`. This approach prevents path traversal attacks and ensures that the file operations are restricted to the intended directory.

Changes to implement:
1. Modify the `deleteImage` method in `SharpImageProcessingService` to normalize the file path using `path.resolve` and validate that it starts with `uploadDir`.
2. Update the `DELETE /api/uploads/photo/:filename` route handler to ensure the filename is sanitized and validated before passing it to the `deleteImage` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
