### PR TITLE
Fix ruff step in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -84,8 +84,8 @@ jobs:
 
       - name: 🦀 Format with Ruff
         run: |
-          uv run pnpm format:ai
-          uv run pnpm lint:fix:ai
+          pnpm format:ai
+          pnpm lint:fix:ai
 
       - name: 📝 Check for changes
         id: verify-changed-files


### PR DESCRIPTION
## Summary
- run pnpm directly in the `format.yml` ruff step

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68511c5a15f08320ae2efad08fbbd6ee