### PR TITLE
📝 docs: add Docker quickstart with Redis

### DIFF
--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -100,6 +100,32 @@ docker run -p 8000:8000 poo-tracker-ai
 docker run -p 8000:8000 -e REDIS_URL=redis://your-redis-host:6379 poo-tracker-ai
 ```
 
+#### Docker + Redis Quickstart
+
+Running the container with a Redis instance lets the service cache results and improves
+overall performance. Specify the `REDIS_URL` and `PORT` environment variables when starting
+the image.
+
+```bash
+# Launch Redis (optional)
+docker run -d --name poo-redis -p 6379:6379 redis:7
+
+# Build the AI service image
+docker build -t poo-tracker-ai .
+
+# Run the service with environment variables
+docker run --rm -p 8000:8000 \
+  -e REDIS_URL=redis://localhost:6379 \
+  -e PORT=8000 \
+  poo-tracker-ai
+```
+
+Once running, the API exposes the following endpoints:
+
+- `http://localhost:8000/health`
+- `http://localhost:8000/analyze`
+- `http://localhost:8000/docs`
+
 ## 🌐 API Endpoints
 
 ### Health Check

--- a/ai-service/tests/test_comprehensive.py
+++ b/ai-service/tests/test_comprehensive.py
@@ -48,7 +48,7 @@ class TestHealthEndpoint:
             assert "version" in data
             assert isinstance(data["redis_connected"], bool)
             assert isinstance(data["ml_models_loaded"], bool)
-            assert isinstance(data["response_time_ms"], (int, float))
+            assert isinstance(data["response_time_ms"], int | float)
 
     def test_health_endpoint_degraded(self):
         """Test health endpoint returns degraded status when Redis is down."""

--- a/ai-service/tests/test_config_utils.py
+++ b/ai-service/tests/test_config_utils.py
@@ -92,7 +92,7 @@ class TestHealthMetricsCalculator:
     def test_calculate_overall_score_empty(self):
         """Test overall score calculation with empty data."""
         result = self.calculator.calculate_overall_score([])
-        assert isinstance(result, (int, float))
+        assert isinstance(result, int | float)
         assert 0 <= result <= 100
 
     def test_calculate_bristol_score(self):
@@ -103,14 +103,14 @@ class TestHealthMetricsCalculator:
             {"bristol_type": 5},
         ]
         result = self.calculator.calculate_bristol_score(sample_entries)
-        assert isinstance(result, (int, float))
+        assert isinstance(result, int | float)
         assert 0 <= result <= 100
 
     def test_calculate_frequency_score(self):
         """Test frequency score calculation."""
         sample_entries = []
         result = self.calculator.calculate_frequency_score(sample_entries)
-        assert isinstance(result, (int, float))
+        assert isinstance(result, int | float)
         assert 0 <= result <= 100
 
     def test_detect_health_issues(self):

--- a/ai-service/tests/test_services.py
+++ b/ai-service/tests/test_services.py
@@ -132,7 +132,9 @@ class TestCacheManager:
         mock_redis_client.ping.side_effect = Exception("Connection failed")
         mock_redis.return_value = mock_redis_client
 
-        with pytest.raises(Exception):
+        import redis
+
+        with pytest.raises(redis.exceptions.RedisError):
             await self.cache_manager.ping()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- document docker usage with Redis in `ai-service` README
- fix lint errors in test files

## Testing
- `uvx ruff format --check .`
- `uvx ruff check .`
- `uvx pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68511b009fec83209e0202ea2cc8a213