### PR TITLE
Fix README API URL var

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -214,7 +214,7 @@ Create `.env.local` in the frontend directory:
 
 ```env
 # API Configuration
-VITE_API_BASE_URL=http://localhost:3002
+VITE_API_URL=http://localhost:3002
 VITE_AI_SERVICE_URL=http://localhost:8001
 
 # Feature Flags


### PR DESCRIPTION
## Summary
- update env variable name to `VITE_API_URL`
- remove all mentions of old `VITE_API_BASE_URL`

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685119705fa08320bb078d4736c68083