### PR TITLE
📚 docs: warn about docker-compose credentials

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -58,6 +58,11 @@ pnpm --filter @poo-tracker/backend dev
 pnpm dev:backend
 ```
 
+> **Security Note**: The default usernames and passwords in
+> [`docker-compose.yml`](../docker-compose.yml) are for **local development
+> only**. Generate unique, strong credentials for PostgreSQL, MinIO and Redis
+> before deploying to production.
+
 ### Manual Setup (if needed)
 
 ```bash


### PR DESCRIPTION
## Summary
- add security note in backend README about default docker-compose credentials

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68511a758054832080ef26b0b904ef39