### PR TITLE
Add Winston logger to auth middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ JWT_EXPIRES_IN="7d"
 
 # App
 NODE_ENV="development"
+
+# Logging
+LOG_LEVEL="info"
+LOG_FORMAT="text"

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,6 @@
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",
     "clean": "pnpm --package=rimraf dlx rimraf dist node_modules",
-    
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:migrate:prod": "prisma migrate deploy",
@@ -22,7 +21,6 @@
     "db:studio": "prisma studio",
     "db:reset": "prisma migrate reset",
     "db:constraints": "tsx src/utils/add-constraints.ts",
-    
     "type-check": "tsc --noEmit"
   },
   "engines": {
@@ -45,9 +43,11 @@
     "redis": "^5.5.6",
     "sharp": "^0.34.2",
     "uuid": "^11.1.0",
+    "winston": "^3.17.0",
     "zod": "^3.25.64"
   },
   "devDependencies": {
+    "@types/winston": "^2.4.4",
     "@types/bcryptjs": "^2.4.6",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -38,6 +38,12 @@ export const config = {
     baseUrl: process.env.UPLOAD_BASE_URL ?? 'http://localhost:3002',
     maxFileSize: parseInt(process.env.MAX_FILE_SIZE ?? '5242880'), // 5MB
     allowedTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'] as const
+  },
+
+  // Logging
+  log: {
+    level: process.env.LOG_LEVEL ?? 'info',
+    format: process.env.LOG_FORMAT ?? 'text'
   }
 } as const
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import { config } from '../config'
+import { logger } from '../utils/logger'
 
 export interface AuthenticatedRequest extends Request {
   userId?: string
@@ -14,28 +15,28 @@ export const authenticateToken = (
   const authHeader = req.headers.authorization
   const token = authHeader?.split(' ')[1] // Bearer TOKEN
 
-  console.log(
-    '🔐 Auth middleware - Headers:',
-    typeof authHeader === 'string' ? 'Present' : 'Missing'
+  logger.debug(
+    `🔐 Auth middleware - Headers: ${typeof authHeader === 'string' ? 'Present' : 'Missing'}`
   )
 
   if (token === undefined || token === '') {
-    console.log('❌ Auth middleware - No token provided')
+    logger.warn('❌ Auth middleware - No token provided')
     res.status(401).json({ error: 'Access token required' })
     return
   }
 
-  console.log('🎫 Auth middleware - Token received:', token.substring(0, 20) + '...')
+  logger.debug(`🎫 Auth middleware - Token received: ${token.substring(0, 20)}...`)
 
   try {
     const decoded = jwt.verify(token, config.jwt.secret) as { userId: string }
-    console.log('✅ Auth middleware - Token valid, userId:', decoded.userId)
+    logger.info(`✅ Auth middleware - Token valid, userId: ${decoded.userId}`)
     req.userId = decoded.userId
     next()
   } catch (error) {
-    console.log(
-      '❌ Auth middleware - Token invalid:',
-      error instanceof Error ? error.message : 'Unknown error'
+    logger.error(
+      `❌ Auth middleware - Token invalid: ${
+        error instanceof Error ? error.message : 'Unknown error'
+      }`
     )
     res.status(403).json({ error: 'Invalid or expired token' })
   }

--- a/backend/src/routes/__tests__/auth.test.ts
+++ b/backend/src/routes/__tests__/auth.test.ts
@@ -27,6 +27,10 @@ vi.mock('../../config', () => ({
     jwt: {
       secret: 'test-secret-key',
       expiresIn: '7d'
+    },
+    log: {
+      level: 'debug',
+      format: 'text'
     }
   }
 }))

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,17 @@
+import { createLogger, format, transports } from 'winston'
+import { config } from '../config'
+
+const logger = createLogger({
+  level: config.log.level,
+  format:
+    config.log.format === 'json'
+      ? format.combine(format.timestamp(), format.json())
+      : format.combine(
+          format.colorize(),
+          format.timestamp(),
+          format.printf(({ level, message, timestamp }) => `${timestamp} [${level}]: ${message}`)
+        ),
+  transports: [new transports.Console()]
+})
+
+export { logger }


### PR DESCRIPTION
## Summary
- create a reusable logger using winston
- configure log level and format via `config.ts`
- log auth middleware events with the logger
- update auth middleware tests for logger usage
- mock logging config in route tests
- document log variables in `.env.example`

## Testing
- `pnpm --filter @poo-tracker/backend run db:generate`
- `pnpm --filter @poo-tracker/backend run type-check`
- `pnpm --filter @poo-tracker/backend test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68511a7f91748320bf2db65d0bf1e2ef