### PR TITLE
Document env vars for all packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Ever wondered if your gut's on a winning streak, or if your last kebab is about 
 
    ```bash
    cp .env.example .env
-   # Edit .env with your configuration
+   cp frontend/.env.example frontend/.env.local
+   cp backend/.env.example backend/.env
+   cp ai-service/.env.example ai-service/.env
+   # Edit each file with your local values
    ```
 
 4. **Start the services:**
@@ -78,6 +81,19 @@ Ever wondered if your gut's on a winning streak, or if your last kebab is about 
 - **AI Service**: Python + FastAPI + scikit-learn
 - **Infrastructure**: Docker + Docker Compose
 - **Package Management**: pnpm (Node.js) + uv (Python)
+
+## 🗝️ Environment Variables
+
+Each package ships with an `.env.example` file. Copy them and tweak the values before running anything:
+
+```bash
+cp .env.example .env
+cp frontend/.env.example frontend/.env.local
+cp backend/.env.example backend/.env
+cp ai-service/.env.example ai-service/.env
+```
+
+These example files contain **sample credentials only**. Replace them with your real secrets and **never commit private keys or passwords** to the repository.
 
 ## 📖 What's the fucking point?
 

--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -216,6 +216,8 @@ ai-service/
 
 ### Environment Variables
 
+Copy `ai-service/.env.example` to `.env` and update values as needed.
+
 - `REDIS_URL` - Redis connection URL (default: `redis://localhost:6379`)
 - `PORT` - Service port (default: 8000)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,25 @@
+# Backend Environment Variables
+
+# Database
+DATABASE_URL="postgresql://poo_user:secure_password_123@localhost:5432/poo_tracker"
+
+# JWT Authentication
+JWT_SECRET="your-super-secret-jwt-key"
+JWT_EXPIRES_IN="7d"
+
+# S3/MinIO Storage
+S3_ENDPOINT="http://localhost:9000"
+S3_BUCKET="poo-photos"
+S3_ACCESS_KEY="minioadmin"
+S3_SECRET_KEY="minioadmin123"
+S3_REGION="us-east-1"
+
+# AI Service Integration
+AI_SERVICE_URL="http://localhost:8001"
+
+# Server Configuration
+PORT=3002
+NODE_ENV="development"
+
+# Optional: Redis for caching
+REDIS_URL="redis://localhost:6379"

--- a/backend/README.md
+++ b/backend/README.md
@@ -252,7 +252,7 @@ backend/
 
 ### Environment Variables
 
-Required variables in `.env`:
+Copy `backend/.env.example` to `.env` and adjust the values:
 
 ```env
 # Database

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,13 @@
+# Frontend Environment Variables
+
+# API Configuration
+VITE_API_BASE_URL=http://localhost:3002
+VITE_AI_SERVICE_URL=http://localhost:8001
+
+# Feature Flags
+VITE_ENABLE_ANALYTICS=true
+VITE_ENABLE_PHOTO_UPLOAD=true
+
+# S3/MinIO Configuration (for direct uploads if needed)
+VITE_S3_BUCKET=poo-photos
+VITE_S3_ENDPOINT=http://localhost:9000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -210,7 +210,7 @@ The frontend communicates with:
 
 ### Environment Variables
 
-Create `.env.local` in the frontend directory:
+Copy `frontend/.env.example` to `.env.local` and adjust the values:
 
 ```env
 # API Configuration


### PR DESCRIPTION
## Summary
- add example env files for frontend & backend
- document environment variables in each package README
- add consolidated env var section to root README

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68511ab54d8c8320b7bb3d54dde6397e