### PR TITLE
🐘 fix: poll Postgres readiness in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -35,9 +35,12 @@ fi
 echo "🐳 Starting Docker services..."
 pnpm docker:up
 
-# Wait for PostgreSQL to be ready
+# Wait for PostgreSQL to be ready using pg_isready
 echo "⏳ Waiting for PostgreSQL to be ready..."
-sleep 10
+until docker compose exec -T postgres pg_isready -U poo_user -d poo_tracker >/dev/null 2>&1; do
+    echo "🔄 Postgres not ready yet, retrying in 1s..."
+    sleep 1
+done
 
 # Run database migrations
 echo "🗄️ Running database migrations..."


### PR DESCRIPTION
## Summary
- use `pg_isready` inside docker loop to wait for the DB

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68511ac22b908320b090716ea79858ae