### PR TITLE
Unify bowel movement domain path

### DIFF
--- a/backend/internal/domain/bowelmovement/gorm_model.go
+++ b/backend/internal/domain/bowelmovement/gorm_model.go
@@ -1,4 +1,4 @@
-package bowel_movement
+package bowelmovement
 
 import (
 	"time"
@@ -7,8 +7,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// BowelMovement represents a bowel movement record
-type BowelMovement struct {
+// BowelMovementDB represents a bowel movement record stored via GORM.
+type BowelMovementDB struct {
 	ID          uuid.UUID      `gorm:"type:uuid;primary_key" json:"id"`
 	UserID      uuid.UUID      `gorm:"type:uuid;not null;index" json:"user_id"`
 	Timestamp   time.Time      `gorm:"not null;index" json:"timestamp"`
@@ -26,7 +26,7 @@ type BowelMovement struct {
 }
 
 // BeforeCreate GORM hook to set UUID if not provided
-func (b *BowelMovement) BeforeCreate(tx *gorm.DB) error {
+func (b *BowelMovementDB) BeforeCreate(tx *gorm.DB) error {
 	if b.ID == uuid.Nil {
 		b.ID = uuid.New()
 	}
@@ -34,16 +34,6 @@ func (b *BowelMovement) BeforeCreate(tx *gorm.DB) error {
 }
 
 // TableName returns the table name for BowelMovement
-func (BowelMovement) TableName() string {
+func (BowelMovementDB) TableName() string {
 	return "bowel_movements"
-}
-
-// Repository interface for BowelMovement operations
-type Repository interface {
-	Create(bm *BowelMovement) error
-	GetByID(id uuid.UUID) (*BowelMovement, error)
-	GetByUserID(userID uuid.UUID, limit, offset int) ([]*BowelMovement, error)
-	Update(bm *BowelMovement) error
-	Delete(id uuid.UUID) error
-	GetByDateRange(userID uuid.UUID, start, end time.Time) ([]*BowelMovement, error)
 }

--- a/backend/internal/infrastructure/database/postgres.go
+++ b/backend/internal/infrastructure/database/postgres.go
@@ -5,7 +5,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
-	"github.com/kjanat/poo-tracker/backend/internal/domain/bowel_movement"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/bowelmovement"
 	"github.com/kjanat/poo-tracker/backend/internal/domain/user"
 )
 
@@ -50,6 +50,6 @@ func (p *PostgreSQLDatabase) Migrate() error {
 	// Auto-migrate domain models
 	return p.db.AutoMigrate(
 		&user.User{},
-		&bowel_movement.BowelMovement{},
+		&bowelmovement.BowelMovementDB{},
 	)
 }

--- a/backend/internal/infrastructure/database/sqlite.go
+++ b/backend/internal/infrastructure/database/sqlite.go
@@ -8,7 +8,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
-	"github.com/kjanat/poo-tracker/backend/internal/domain/bowel_movement"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/bowelmovement"
 	"github.com/kjanat/poo-tracker/backend/internal/domain/user"
 )
 
@@ -48,6 +48,6 @@ func (s *SQLiteDatabase) Migrate() error {
 	// Auto-migrate domain models
 	return s.db.AutoMigrate(
 		&user.User{},
-		&bowel_movement.BowelMovement{},
+		&bowelmovement.BowelMovementDB{},
 	)
 }


### PR DESCRIPTION
## Summary
- move GORM model file into `internal/domain/bowelmovement`
- adjust database imports and migrations for the new package
- delete the obsolete `bowel_movement` directory

## Testing
- `pnpm test:backend` *(fails: unknown fields in StatisticalSummary, undefined service symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1cdb6b48320b4b6ff112e436c83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal naming conventions for improved consistency.
  - Adjusted database migration references to align with updated naming.
- **Chores**
  - Removed unused repository interface from internal files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->