### PR TITLE
Centralize domain error types

### DIFF
--- a/backend/internal/domain/bowelmovement/errors.go
+++ b/backend/internal/domain/bowelmovement/errors.go
@@ -2,7 +2,8 @@ package bowelmovement
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/shared"
 )
 
 // Domain errors
@@ -36,38 +37,18 @@ var (
 	ErrDetailsAlreadyExist = errors.New("details already exist for this bowel movement")
 )
 
-// ValidationError represents a validation error with field information
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+// ValidationError represents a validation error with field information.
+// Deprecated: use shared.ValidationError instead.
+type ValidationError = shared.ValidationError
 
-func (e ValidationError) Error() string {
-	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
-}
+// NewValidationError creates a new validation error.
+// Deprecated: use shared.NewValidationError instead.
+var NewValidationError = shared.NewValidationError
 
-// NewValidationError creates a new validation error
-func NewValidationError(field, message string) ValidationError {
-	return ValidationError{
-		Field:   field,
-		Message: message,
-	}
-}
+// BusinessRuleError represents a business rule violation.
+// Deprecated: use shared.BusinessRuleError instead.
+type BusinessRuleError = shared.BusinessRuleError
 
-// BusinessRuleError represents a business rule violation
-type BusinessRuleError struct {
-	Rule    string `json:"rule"`
-	Message string `json:"message"`
-}
-
-func (e BusinessRuleError) Error() string {
-	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
-}
-
-// NewBusinessRuleError creates a new business rule error
-func NewBusinessRuleError(rule, message string) BusinessRuleError {
-	return BusinessRuleError{
-		Rule:    rule,
-		Message: message,
-	}
-}
+// NewBusinessRuleError creates a new business rule error.
+// Deprecated: use shared.NewBusinessRuleError instead.
+var NewBusinessRuleError = shared.NewBusinessRuleError

--- a/backend/internal/domain/meal/errors.go
+++ b/backend/internal/domain/meal/errors.go
@@ -2,7 +2,8 @@ package meal
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/shared"
 )
 
 // Domain errors
@@ -27,38 +28,18 @@ var (
 	ErrUserNotAuthorized = errors.New("user not authorized to access this meal")
 )
 
-// ValidationError represents a validation error with field information
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+// ValidationError represents a validation error with field information.
+// Deprecated: use shared.ValidationError instead.
+type ValidationError = shared.ValidationError
 
-func (e ValidationError) Error() string {
-	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
-}
+// NewValidationError creates a new validation error.
+// Deprecated: use shared.NewValidationError instead.
+var NewValidationError = shared.NewValidationError
 
-// NewValidationError creates a new validation error
-func NewValidationError(field, message string) ValidationError {
-	return ValidationError{
-		Field:   field,
-		Message: message,
-	}
-}
+// BusinessRuleError represents a business rule violation.
+// Deprecated: use shared.BusinessRuleError instead.
+type BusinessRuleError = shared.BusinessRuleError
 
-// BusinessRuleError represents a business rule violation
-type BusinessRuleError struct {
-	Rule    string `json:"rule"`
-	Message string `json:"message"`
-}
-
-func (e BusinessRuleError) Error() string {
-	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
-}
-
-// NewBusinessRuleError creates a new business rule error
-func NewBusinessRuleError(rule, message string) BusinessRuleError {
-	return BusinessRuleError{
-		Rule:    rule,
-		Message: message,
-	}
-}
+// NewBusinessRuleError creates a new business rule error.
+// Deprecated: use shared.NewBusinessRuleError instead.
+var NewBusinessRuleError = shared.NewBusinessRuleError

--- a/backend/internal/domain/medication/errors.go
+++ b/backend/internal/domain/medication/errors.go
@@ -2,7 +2,8 @@ package medication
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/shared"
 )
 
 // Domain errors
@@ -32,38 +33,18 @@ var (
 	ErrUserNotAuthorized = errors.New("user not authorized to access this medication")
 )
 
-// ValidationError represents a validation error with field information
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+// ValidationError represents a validation error with field information.
+// Deprecated: use shared.ValidationError instead.
+type ValidationError = shared.ValidationError
 
-func (e ValidationError) Error() string {
-	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
-}
+// NewValidationError creates a new validation error.
+// Deprecated: use shared.NewValidationError instead.
+var NewValidationError = shared.NewValidationError
 
-// NewValidationError creates a new validation error
-func NewValidationError(field, message string) ValidationError {
-	return ValidationError{
-		Field:   field,
-		Message: message,
-	}
-}
+// BusinessRuleError represents a business rule violation.
+// Deprecated: use shared.BusinessRuleError instead.
+type BusinessRuleError = shared.BusinessRuleError
 
-// BusinessRuleError represents a business rule violation
-type BusinessRuleError struct {
-	Rule    string `json:"rule"`
-	Message string `json:"message"`
-}
-
-func (e BusinessRuleError) Error() string {
-	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
-}
-
-// NewBusinessRuleError creates a new business rule error
-func NewBusinessRuleError(rule, message string) BusinessRuleError {
-	return BusinessRuleError{
-		Rule:    rule,
-		Message: message,
-	}
-}
+// NewBusinessRuleError creates a new business rule error.
+// Deprecated: use shared.NewBusinessRuleError instead.
+var NewBusinessRuleError = shared.NewBusinessRuleError

--- a/backend/internal/domain/shared/error_types.go
+++ b/backend/internal/domain/shared/error_types.go
@@ -1,0 +1,35 @@
+package shared
+
+import "fmt"
+
+// ValidationError represents a validation error with field information
+// Shared across domain packages.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
+}
+
+// NewValidationError creates a new validation error
+func NewValidationError(field, message string) ValidationError {
+	return ValidationError{Field: field, Message: message}
+}
+
+// BusinessRuleError represents a business rule violation
+// Shared across domain packages.
+type BusinessRuleError struct {
+	Rule    string `json:"rule"`
+	Message string `json:"message"`
+}
+
+func (e BusinessRuleError) Error() string {
+	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
+}
+
+// NewBusinessRuleError creates a new business rule error
+func NewBusinessRuleError(rule, message string) BusinessRuleError {
+	return BusinessRuleError{Rule: rule, Message: message}
+}

--- a/backend/internal/domain/symptom/errors.go
+++ b/backend/internal/domain/symptom/errors.go
@@ -2,7 +2,8 @@ package symptom
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/shared"
 )
 
 // Domain errors
@@ -20,38 +21,18 @@ var (
 	ErrDuplicateSymptom       = errors.New("duplicate symptom entry detected")
 )
 
-// ValidationError represents a validation error with field information
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+// ValidationError represents a validation error with field information.
+// Deprecated: use shared.ValidationError instead.
+type ValidationError = shared.ValidationError
 
-func (e ValidationError) Error() string {
-	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
-}
+// NewValidationError creates a new validation error.
+// Deprecated: use shared.NewValidationError instead.
+var NewValidationError = shared.NewValidationError
 
-// NewValidationError creates a new validation error
-func NewValidationError(field, message string) ValidationError {
-	return ValidationError{
-		Field:   field,
-		Message: message,
-	}
-}
+// BusinessRuleError represents a business rule violation.
+// Deprecated: use shared.BusinessRuleError instead.
+type BusinessRuleError = shared.BusinessRuleError
 
-// BusinessRuleError represents a business rule violation
-type BusinessRuleError struct {
-	Rule    string `json:"rule"`
-	Message string `json:"message"`
-}
-
-func (e BusinessRuleError) Error() string {
-	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
-}
-
-// NewBusinessRuleError creates a new business rule error
-func NewBusinessRuleError(rule, message string) BusinessRuleError {
-	return BusinessRuleError{
-		Rule:    rule,
-		Message: message,
-	}
-}
+// NewBusinessRuleError creates a new business rule error.
+// Deprecated: use shared.NewBusinessRuleError instead.
+var NewBusinessRuleError = shared.NewBusinessRuleError

--- a/backend/internal/domain/user/errors.go
+++ b/backend/internal/domain/user/errors.go
@@ -2,7 +2,8 @@ package user
 
 import (
 	"errors"
-	"fmt"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/shared"
 )
 
 // Domain errors
@@ -43,38 +44,18 @@ var (
 	ErrUserNotAuthorized = errors.New("user not authorized to perform this action")
 )
 
-// ValidationError represents a validation error with field information
-type ValidationError struct {
-	Field   string `json:"field"`
-	Message string `json:"message"`
-}
+// ValidationError represents a validation error with field information.
+// Deprecated: use shared.ValidationError instead.
+type ValidationError = shared.ValidationError
 
-func (e ValidationError) Error() string {
-	return fmt.Sprintf("validation error on field '%s': %s", e.Field, e.Message)
-}
+// NewValidationError creates a new validation error.
+// Deprecated: use shared.NewValidationError instead.
+var NewValidationError = shared.NewValidationError
 
-// NewValidationError creates a new validation error
-func NewValidationError(field, message string) ValidationError {
-	return ValidationError{
-		Field:   field,
-		Message: message,
-	}
-}
+// BusinessRuleError represents a business rule violation.
+// Deprecated: use shared.BusinessRuleError instead.
+type BusinessRuleError = shared.BusinessRuleError
 
-// BusinessRuleError represents a business rule violation
-type BusinessRuleError struct {
-	Rule    string `json:"rule"`
-	Message string `json:"message"`
-}
-
-func (e BusinessRuleError) Error() string {
-	return fmt.Sprintf("business rule violation '%s': %s", e.Rule, e.Message)
-}
-
-// NewBusinessRuleError creates a new business rule error
-func NewBusinessRuleError(rule, message string) BusinessRuleError {
-	return BusinessRuleError{
-		Rule:    rule,
-		Message: message,
-	}
-}
+// NewBusinessRuleError creates a new business rule error.
+// Deprecated: use shared.NewBusinessRuleError instead.
+var NewBusinessRuleError = shared.NewBusinessRuleError


### PR DESCRIPTION
## Summary
- add shared error types for ValidationError and BusinessRuleError
- alias old error types in domain packages to new shared types

## Testing
- `pnpm lint`
- `pnpm lint:fix`
- `pnpm build`
- `pnpm test`
- `pnpm lint:backend` *(fails: typecheck issues)*
- `pnpm test:backend` *(fails: could not compile backend)*
- `pnpm build:backend` *(fails: could not compile backend)*
- `cd ai-service && uvx ruff format --check .`
- `uvx ruff check .`
- `uvx pytest` *(fails: missing dependencies)*
- `uvx mypy main.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1f0ca8c8320a9328521509701c2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized error handling by consolidating validation and business rule error types into a shared component, reducing duplication across multiple areas of the app. Existing error types in related features now reference the shared definitions.
- **Chores**
  - Deprecated local error type definitions in favor of shared versions to streamline maintenance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->