### PR TITLE
Enhance password validation in backend

### DIFF
--- a/backend/internal/infrastructure/service/user_service.go
+++ b/backend/internal/infrastructure/service/user_service.go
@@ -501,7 +501,26 @@ func (s *UserService) ValidatePassword(password string) error {
 	if len(password) > 128 {
 		return user.ErrPasswordTooLong
 	}
-	// Add more password validation rules as needed
+
+	var hasUpper, hasLower, hasDigit, hasSpecial bool
+	for _, ch := range password {
+		switch {
+		case ch >= 'A' && ch <= 'Z':
+			hasUpper = true
+		case ch >= 'a' && ch <= 'z':
+			hasLower = true
+		case ch >= '0' && ch <= '9':
+			hasDigit = true
+		default:
+			// treat any other character as special
+			hasSpecial = true
+		}
+	}
+
+	if !hasUpper || !hasLower || !hasDigit || !hasSpecial {
+		return user.ErrWeakPassword
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- strengthen `ValidatePassword` complexity requirements
- test password complexity rules

## Testing
- `golangci-lint run ./...`
- `go test ./...` *(fails: medication.Medication is not a type)*

------
https://chatgpt.com/codex/tasks/task_e_68563583854483208818490bb8f20d30