### PR TITLE
Add percentile helper for analytics

### DIFF
--- a/backend/internal/infrastructure/service/analytics/shared/helpers.go
+++ b/backend/internal/infrastructure/service/analytics/shared/helpers.go
@@ -6,6 +6,34 @@ import (
 	"time"
 )
 
+// calculatePercentile returns the value at the given percentile from a slice of
+// float64 values. The slice is copied and sorted internally. If the slice is
+// empty, the function returns 0. If it contains a single element, that value is
+// returned. Percentile should be provided as a decimal (e.g., 0.25 for 25%).
+func calculatePercentile(values []float64, percentile float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	if len(values) == 1 {
+		return values[0]
+	}
+
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+
+	rank := percentile * float64(len(sorted)-1)
+	lower := int(math.Floor(rank))
+	upper := int(math.Ceil(rank))
+
+	if lower == upper {
+		return sorted[lower]
+	}
+
+	weight := rank - float64(lower)
+	return sorted[lower]*(1-weight) + sorted[upper]*weight
+}
+
 // CalculateStatistics computes basic statistical metrics for a slice of float64 values
 func CalculateStatistics(values []float64) StatisticalSummary {
 	if len(values) == 0 {
@@ -39,8 +67,8 @@ func CalculateStatistics(values []float64) StatisticalSummary {
 	stdDev := math.Sqrt(varianceSum / float64(len(values)))
 
 	// Calculate percentiles
-	p25Index := int(float64(len(sortedValues)) * 0.25)
-	p75Index := int(float64(len(sortedValues)) * 0.75)
+	p25 := calculatePercentile(sortedValues, 0.25)
+	p75 := calculatePercentile(sortedValues, 0.75)
 
 	return StatisticalSummary{
 		Count:        len(values),
@@ -49,8 +77,8 @@ func CalculateStatistics(values []float64) StatisticalSummary {
 		StdDev:       stdDev,
 		Min:          sortedValues[0],
 		Max:          sortedValues[len(sortedValues)-1],
-		Percentile25: sortedValues[p25Index],
-		Percentile75: sortedValues[p75Index],
+		Percentile25: p25,
+		Percentile75: p75,
 	}
 }
 

--- a/backend/internal/infrastructure/service/analytics/shared/helpers_test.go
+++ b/backend/internal/infrastructure/service/analytics/shared/helpers_test.go
@@ -1,0 +1,40 @@
+package shared
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculatePercentile(t *testing.T) {
+	values := []float64{1, 2, 3, 4}
+
+	p25 := calculatePercentile(values, 0.25)
+	p75 := calculatePercentile(values, 0.75)
+
+	if math.Abs(p25-1.75) > 1e-9 {
+		t.Errorf("expected 1.75 for 25th percentile, got %v", p25)
+	}
+	if math.Abs(p75-3.25) > 1e-9 {
+		t.Errorf("expected 3.25 for 75th percentile, got %v", p75)
+	}
+}
+
+func TestCalculatePercentileEdgeCases(t *testing.T) {
+	if val := calculatePercentile([]float64{}, 0.25); val != 0 {
+		t.Errorf("expected 0 for empty slice, got %v", val)
+	}
+	if val := calculatePercentile([]float64{5}, 0.75); val != 5 {
+		t.Errorf("expected 5 for single element slice, got %v", val)
+	}
+}
+
+func TestCalculateStatisticsUsesPercentiles(t *testing.T) {
+	stats := CalculateStatistics([]float64{1, 2, 3, 4})
+
+	if math.Abs(stats.Percentile25-1.75) > 1e-9 {
+		t.Errorf("expected stats.Percentile25 to be 1.75, got %v", stats.Percentile25)
+	}
+	if math.Abs(stats.Percentile75-3.25) > 1e-9 {
+		t.Errorf("expected stats.Percentile75 to be 3.25, got %v", stats.Percentile75)
+	}
+}


### PR DESCRIPTION
## Summary
- add `calculatePercentile` helper for analytics stats
- plug percentile helper into `CalculateStatistics`
- test percentile calculations including edge cases

## Testing
- `go test -C backend ./...` *(fails: medication.Medication is not a type)*

------
https://chatgpt.com/codex/tasks/task_e_6856381627908320b6a138051a972d1f