### PR TITLE
Fix userID context extraction

### DIFF
--- a/backend/internal/infrastructure/http/handlers/helper.go
+++ b/backend/internal/infrastructure/http/handlers/helper.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// extractUserID retrieves the user_id from the context ensuring it is a string.
+// If the value is missing or not a string, it writes a 401 response and returns false.
+func extractUserID(c *gin.Context) (string, bool) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return "", false
+	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return "", false
+	}
+	return userIDStr, true
+}

--- a/backend/internal/infrastructure/http/handlers/user_handler.go
+++ b/backend/internal/infrastructure/http/handlers/user_handler.go
@@ -155,9 +155,14 @@ func (h *UserHandler) GetProfile(c *gin.Context) {
 		})
 		return
 	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
 
 	// Get user by ID
-	userEntity, err := h.userService.GetByID(c.Request.Context(), userID.(string))
+	userEntity, err := h.userService.GetByID(c.Request.Context(), userIDStr)
 	if err != nil {
 		switch err {
 		case user.ErrUserNotFound:
@@ -199,6 +204,11 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		})
 		return
 	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
 
 	var req userDto.UpdateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -213,7 +223,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 	input := req.ToUpdateUserInput()
 
 	// Update user
-	userEntity, err := h.userService.Update(c.Request.Context(), userID.(string), input)
+	userEntity, err := h.userService.Update(c.Request.Context(), userIDStr, input)
 	if err != nil {
 		switch err {
 		case user.ErrUserNotFound:
@@ -266,6 +276,11 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 		})
 		return
 	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
 
 	var req userDto.ChangePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -283,7 +298,7 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 	}
 
 	// Change password
-	err := h.userService.ChangePassword(c.Request.Context(), userID.(string), input)
+	err := h.userService.ChangePassword(c.Request.Context(), userIDStr, input)
 	if err != nil {
 		switch err {
 		case user.ErrUserNotFound:
@@ -330,9 +345,14 @@ func (h *UserHandler) GetSettings(c *gin.Context) {
 		})
 		return
 	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
 
 	// Get user settings
-	settings, err := h.userService.GetSettings(c.Request.Context(), userID.(string))
+	settings, err := h.userService.GetSettings(c.Request.Context(), userIDStr)
 	if err != nil {
 		switch err {
 		case user.ErrUserSettingsNotFound:
@@ -373,6 +393,11 @@ func (h *UserHandler) UpdateSettings(c *gin.Context) {
 		})
 		return
 	}
+	userIDStr, ok := userID.(string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
 
 	var req userDto.UpdateSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -387,7 +412,7 @@ func (h *UserHandler) UpdateSettings(c *gin.Context) {
 	input := req.ToUpdateSettingsInput()
 
 	// Update settings
-	settings, err := h.userService.UpdateSettings(c.Request.Context(), userID.(string), input)
+	settings, err := h.userService.UpdateSettings(c.Request.Context(), userIDStr, input)
 	if err != nil {
 		switch err {
 		case user.ErrUserNotFound:

--- a/backend/internal/infrastructure/http/handlers/user_handler.go
+++ b/backend/internal/infrastructure/http/handlers/user_handler.go
@@ -148,16 +148,8 @@ func (h *UserHandler) Login(c *gin.Context) {
 // @Router /api/v1/users/profile [get]
 func (h *UserHandler) GetProfile(c *gin.Context) {
 	// Get user ID from JWT context (will be set by auth middleware)
-	userID, exists := c.Get("user_id")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "User not authenticated",
-		})
-		return
-	}
-	userIDStr, ok := userID.(string)
+	userIDStr, ok := extractUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
@@ -197,16 +189,8 @@ func (h *UserHandler) GetProfile(c *gin.Context) {
 // @Router /api/v1/users/profile [put]
 func (h *UserHandler) UpdateProfile(c *gin.Context) {
 	// Get user ID from JWT context
-	userID, exists := c.Get("user_id")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "User not authenticated",
-		})
-		return
-	}
-	userIDStr, ok := userID.(string)
+	userIDStr, ok := extractUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
@@ -269,16 +253,8 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 // @Router /api/v1/users/change-password [post]
 func (h *UserHandler) ChangePassword(c *gin.Context) {
 	// Get user ID from JWT context
-	userID, exists := c.Get("user_id")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "User not authenticated",
-		})
-		return
-	}
-	userIDStr, ok := userID.(string)
+	userIDStr, ok := extractUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
@@ -338,16 +314,8 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 // @Router /api/v1/users/settings [get]
 func (h *UserHandler) GetSettings(c *gin.Context) {
 	// Get user ID from JWT context
-	userID, exists := c.Get("user_id")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "User not authenticated",
-		})
-		return
-	}
-	userIDStr, ok := userID.(string)
+	userIDStr, ok := extractUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
@@ -386,16 +354,8 @@ func (h *UserHandler) GetSettings(c *gin.Context) {
 // @Router /api/v1/users/settings [put]
 func (h *UserHandler) UpdateSettings(c *gin.Context) {
 	// Get user ID from JWT context
-	userID, exists := c.Get("user_id")
-	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "User not authenticated",
-		})
-		return
-	}
-	userIDStr, ok := userID.(string)
+	userIDStr, ok := extractUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 

--- a/backend/internal/infrastructure/http/handlers/user_handler_test.go
+++ b/backend/internal/infrastructure/http/handlers/user_handler_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"context"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/user"
+)
+
+// stubUserService implements user.Service with no-op methods for testing
+// Only methods relevant to these tests need basic behavior
+
+type stubUserService struct{}
+
+func (s *stubUserService) Create(ctx context.Context, input *user.CreateUserInput) (*user.User, error) {
+	return nil, nil
+}
+func (s *stubUserService) GetByID(ctx context.Context, id string) (*user.User, error) {
+	return &user.User{ID: id}, nil
+}
+func (s *stubUserService) GetByEmail(ctx context.Context, email string) (*user.User, error) {
+	return nil, nil
+}
+func (s *stubUserService) GetByUsername(ctx context.Context, username string) (*user.User, error) {
+	return nil, nil
+}
+func (s *stubUserService) Update(ctx context.Context, id string, input *user.UpdateUserInput) (*user.User, error) {
+	return &user.User{ID: id}, nil
+}
+func (s *stubUserService) Delete(ctx context.Context, id string) error { return nil }
+func (s *stubUserService) List(ctx context.Context, limit, offset int) ([]*user.User, error) {
+	return nil, nil
+}
+func (s *stubUserService) ListWithCount(ctx context.Context, limit, offset int) ([]*user.User, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubUserService) Register(ctx context.Context, input *user.RegisterInput) (*user.User, error) {
+	return nil, nil
+}
+func (s *stubUserService) Login(ctx context.Context, input *user.LoginInput) (*user.LoginResult, error) {
+	return nil, nil
+}
+func (s *stubUserService) ChangePassword(ctx context.Context, userID string, input *user.ChangePasswordInput) error {
+	return nil
+}
+func (s *stubUserService) DeactivateAccount(ctx context.Context, userID string) error { return nil }
+func (s *stubUserService) GetSettings(ctx context.Context, userID string) (*user.UserSettings, error) {
+	return &user.UserSettings{UserID: userID}, nil
+}
+func (s *stubUserService) UpdateSettings(ctx context.Context, userID string, input *user.UpdateSettingsInput) (*user.UserSettings, error) {
+	return &user.UserSettings{UserID: userID}, nil
+}
+func (s *stubUserService) ValidateEmail(ctx context.Context, email string) error       { return nil }
+func (s *stubUserService) ValidateUsername(ctx context.Context, username string) error { return nil }
+func (s *stubUserService) ValidatePassword(password string) error                      { return nil }
+
+var _ user.Service = (*stubUserService)(nil)
+
+func TestHandlers_InvalidUserIDContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &stubUserService{}
+	h := NewUserHandler(svc)
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		handler gin.HandlerFunc
+	}{
+		{"GetProfile", http.MethodGet, "/profile", h.GetProfile},
+		{"UpdateProfile", http.MethodPut, "/profile", h.UpdateProfile},
+		{"ChangePassword", http.MethodPost, "/change-password", h.ChangePassword},
+		{"GetSettings", http.MethodGet, "/settings", h.GetSettings},
+		{"UpdateSettings", http.MethodPut, "/settings", h.UpdateSettings},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set("user_id", 123) // invalid type
+			})
+			router.Handle(tt.method, tt.path, tt.handler)
+
+			req, _ := http.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("expected status 401, got %d", w.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- guard against invalid user_id context values
- add unit tests covering unauthorized responses when context has wrong type

## Testing
- `go test ./internal/infrastructure/http/handlers -run TestHandlers_InvalidUserIDContext -v`

------
https://chatgpt.com/codex/tasks/task_e_68563814045c83208ebe93e3f94adc06