### PR TITLE
Implement meal pattern helpers

### DIFF
--- a/backend/internal/infrastructure/service/analytics/analyzer/patterns.go
+++ b/backend/internal/infrastructure/service/analytics/analyzer/patterns.go
@@ -7,21 +7,22 @@ import (
 	"github.com/kjanat/poo-tracker/backend/internal/domain/bowelmovement"
 	"github.com/kjanat/poo-tracker/backend/internal/domain/meal"
 	"github.com/kjanat/poo-tracker/backend/internal/domain/symptom"
+	"github.com/kjanat/poo-tracker/backend/internal/infrastructure/service/analytics/aggregator"
 	"github.com/kjanat/poo-tracker/backend/internal/infrastructure/service/analytics/shared"
 )
 
 // AnalyzeEatingPatterns identifies patterns in eating habits and their potential impacts
 func (ta *TrendAnalyzer) AnalyzeEatingPatterns(meals []meal.Meal) *shared.EatingPattern {
-	// TODO: Remove this early return once methods are implemented
+	pattern := &shared.EatingPattern{}
+
 	if len(meals) == 0 {
-		return &shared.EatingPattern{}
+		return pattern
 	}
 
-	pattern := &shared.EatingPattern{
-		MealTimings:        []shared.MealTiming{}, // TODO: Implement analyzeMealTimings
-		CommonIngredients:  []string{},            // TODO: Implement identifyCommonIngredients
-		ProblemIngredients: []string{},            // TODO: Implement identifyProblemIngredients
-	}
+	pattern.MealTimings = ta.analyzeMealTimings(meals)
+	pattern.CommonIngredients = ta.identifyCommonIngredients(meals)
+	pattern.ProblemIngredients = ta.identifyProblemIngredients(meals)
+
 	return pattern
 }
 
@@ -82,18 +83,74 @@ func (ta *TrendAnalyzer) analyzeMealTimings(meals []meal.Meal) []shared.MealTimi
 	return timings
 }
 
-func (ta *TrendAnalyzer) identifyCommonSymptomMap(symptoms []symptom.Symptom) map[string]int {
-    if symptoms == nil {
-        return make(map[string]int)
-    }
+// identifyCommonIngredients returns a sorted list of frequently occurring meal
+// attributes. The current model doesn't store detailed ingredient lists, so we
+// approximate ingredients using boolean flags and characteristics such as
+// Dairy, Gluten, FiberRich and SpicyLevel.
+func (ta *TrendAnalyzer) identifyCommonIngredients(meals []meal.Meal) []string {
+	if len(meals) == 0 {
+		return []string{}
+	}
 
-    // Convert symptom list to frequency map
-    freq := make(map[string]int)
-    for _, s := range symptoms {
-        symptomType := s.Type.String()
-        freq[symptomType]++
-    }
-    return freq
+	counts := make(map[string]int)
+	for _, m := range meals {
+		if m.Dairy {
+			counts["dairy"]++
+		}
+		if m.Gluten {
+			counts["gluten"]++
+		}
+		if m.FiberRich {
+			counts["fiber"]++
+		}
+		if m.SpicyLevel != nil && *m.SpicyLevel > aggregator.SpicyThreshold {
+			counts["spicy"]++
+		}
+	}
+
+	type pair struct {
+		name  string
+		count int
+	}
+	pairs := make([]pair, 0, len(counts))
+	for k, v := range counts {
+		pairs = append(pairs, pair{name: k, count: v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].count == pairs[j].count {
+			return pairs[i].name < pairs[j].name
+		}
+		return pairs[i].count > pairs[j].count
+	})
+
+	result := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		result = append(result, p.name)
+	}
+
+	return result
+}
+
+// identifyProblemIngredients attempts to determine ingredients that may cause
+// issues for the user. This requires correlation with symptoms which is not yet
+// implemented, so the function currently returns an empty slice.
+func (ta *TrendAnalyzer) identifyProblemIngredients(meals []meal.Meal) []string {
+	// TODO: implement ingredient-symptom correlation analysis
+	return []string{}
+}
+
+func (ta *TrendAnalyzer) identifyCommonSymptomMap(symptoms []symptom.Symptom) map[string]int {
+	if symptoms == nil {
+		return make(map[string]int)
+	}
+
+	// Convert symptom list to frequency map
+	freq := make(map[string]int)
+	for _, s := range symptoms {
+		symptomType := s.Type.String()
+		freq[symptomType]++
+	}
+	return freq
 }
 
 func (ta *TrendAnalyzer) analyzeBowelFrequency(movements []bowelmovement.BowelMovement) float64 {

--- a/backend/internal/infrastructure/service/analytics/analyzer/patterns_test.go
+++ b/backend/internal/infrastructure/service/analytics/analyzer/patterns_test.go
@@ -1,0 +1,70 @@
+package analyzer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/meal"
+	"github.com/kjanat/poo-tracker/backend/internal/infrastructure/service/analytics/shared"
+)
+
+func TestAnalyzeMealTimings(t *testing.T) {
+	ta := &TrendAnalyzer{}
+	meals := []meal.Meal{
+		{MealTime: time.Date(2024, 6, 1, 8, 0, 0, 0, time.UTC)},
+		{MealTime: time.Date(2024, 6, 1, 12, 15, 0, 0, time.UTC)},
+		{MealTime: time.Date(2024, 6, 2, 12, 30, 0, 0, time.UTC)},
+		{MealTime: time.Date(2024, 6, 3, 20, 0, 0, 0, time.UTC)},
+	}
+
+	got := ta.analyzeMealTimings(meals)
+	expected := []shared.MealTiming{
+		{TimeOfDay: shared.NewTimeOfDay(8, 0), Frequency: 1},
+		{TimeOfDay: shared.NewTimeOfDay(12, 0), Frequency: 2},
+		{TimeOfDay: shared.NewTimeOfDay(20, 0), Frequency: 1},
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestIdentifyCommonIngredients(t *testing.T) {
+	ta := &TrendAnalyzer{}
+	spicy := 3
+	meals := []meal.Meal{
+		{Dairy: true},
+		{Dairy: true, Gluten: true},
+		{Gluten: true},
+		{SpicyLevel: &spicy},
+	}
+
+	got := ta.identifyCommonIngredients(meals)
+	assert.Equal(t, []string{"dairy", "gluten", "spicy"}, got)
+}
+
+func TestIdentifyProblemIngredients(t *testing.T) {
+	ta := &TrendAnalyzer{}
+	meals := []meal.Meal{{Dairy: true}}
+	assert.Empty(t, ta.identifyProblemIngredients(meals))
+}
+
+func TestAnalyzeEatingPatterns(t *testing.T) {
+	ta := &TrendAnalyzer{}
+	spicy := 5
+	meals := []meal.Meal{
+		{MealTime: time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC), Dairy: true},
+		{MealTime: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), Dairy: true, Gluten: true},
+		{MealTime: time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC), Gluten: true},
+		{MealTime: time.Date(2024, 1, 3, 20, 0, 0, 0, time.UTC), SpicyLevel: &spicy},
+	}
+
+	pattern := ta.AnalyzeEatingPatterns(meals)
+	expectedTimings := []shared.MealTiming{
+		{TimeOfDay: shared.NewTimeOfDay(8, 0), Frequency: 1},
+		{TimeOfDay: shared.NewTimeOfDay(12, 0), Frequency: 2},
+		{TimeOfDay: shared.NewTimeOfDay(20, 0), Frequency: 1},
+	}
+	assert.Equal(t, expectedTimings, pattern.MealTimings)
+	assert.Equal(t, []string{"dairy", "gluten", "spicy"}, pattern.CommonIngredients)
+	assert.Empty(t, pattern.ProblemIngredients)
+}


### PR DESCRIPTION
## Summary
- implement logic for `AnalyzeEatingPatterns`
- add `identifyCommonIngredients` and placeholder `identifyProblemIngredients`
- unit tests for new behaviour

## Testing
- `go test ./internal/infrastructure/service/analytics/analyzer -run TestAnalyzeMealTimings -v` *(fails: build constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68563810a0fc8320b829e66d1cb243a2