### PR TITLE
Validate bristol type on creation

### DIFF
--- a/backend/internal/domain/bowelmovement/model.go
+++ b/backend/internal/domain/bowelmovement/model.go
@@ -116,23 +116,24 @@ type BowelMovementDetailsUpdate struct {
 }
 
 // NewBowelMovement creates a new BowelMovement with sensible defaults.
-func NewBowelMovement(userID string, bristolType int) BowelMovement {
-    // Validate Bristol type
-    if bristolType < 1 || bristolType > 7 {
-        bristolType = 4 // Default to normal/healthy type
-    }
-    now := time.Now()
-    return BowelMovement{
-        UserID:       userID,
-        BristolType:  bristolType,
-        CreatedAt:    now,
-        UpdatedAt:    now,
-        RecordedAt:   now,
-        Pain:         1, // Default: minimal pain
-        Strain:       1, // Default: minimal strain
-        Satisfaction: 5, // Default: neutral satisfaction
-        Floaters:     false,
-    }
+func NewBowelMovement(userID string, bristolType int) (BowelMovement, error) {
+	if bristolType < 1 || bristolType > 7 {
+		return BowelMovement{}, ErrInvalidBristolType
+	}
+
+	now := time.Now()
+	bm := BowelMovement{
+		UserID:       userID,
+		BristolType:  bristolType,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		RecordedAt:   now,
+		Pain:         1, // Default: minimal pain
+		Strain:       1, // Default: minimal strain
+		Satisfaction: 5, // Default: neutral satisfaction
+		Floaters:     false,
+	}
+	return bm, nil
 }
 
 // NewBowelMovementDetails creates a new BowelMovementDetails with defaults.

--- a/backend/internal/domain/bowelmovement/model_test.go
+++ b/backend/internal/domain/bowelmovement/model_test.go
@@ -1,0 +1,33 @@
+package bowelmovement
+
+import "testing"
+
+func TestNewBowelMovement(t *testing.T) {
+	tests := []struct {
+		name        string
+		bristolType int
+		wantErr     bool
+	}{
+		{"valid", 3, false},
+		{"invalid low", 0, true},
+		{"invalid high", 8, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bm, err := NewBowelMovement("user1", tt.bristolType)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for bristolType %d", tt.bristolType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if bm.BristolType != tt.bristolType {
+				t.Errorf("expected BristolType %d, got %d", tt.bristolType, bm.BristolType)
+			}
+		})
+	}
+}

--- a/backend/server/bowel_movements_api.go
+++ b/backend/server/bowel_movements_api.go
@@ -63,7 +63,16 @@ func (a *App) createBowelMovement(c *gin.Context) {
 	}
 
 	// Start with a new bowel movement with defaults
-	bm := bm.NewBowelMovement(req.UserID, req.BristolType)
+	bmEntry, err := bm.NewBowelMovement(req.UserID, req.BristolType)
+	if err != nil {
+		if err == bm.ErrInvalidBristolType {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	bm := bmEntry
 
 	// Apply optional fields
 	applyOptionalFields(&bm, &req)


### PR DESCRIPTION
## Summary
- return `(BowelMovement, error)` from `NewBowelMovement`
- handle `ErrInvalidBristolType` in the API layer
- cover valid and invalid Bristol type values with tests

## Testing
- `go test -C backend ./...` *(fails: missing ',' in composite literal and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68563817cde48320900a26b94ce5d5c2