### PR TITLE
Add domain model constructor tests

### DIFF
--- a/backend/internal/domain/meal/model_test.go
+++ b/backend/internal/domain/meal/model_test.go
@@ -1,0 +1,27 @@
+package meal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewMealDefaults(t *testing.T) {
+	mealTime := time.Now()
+	m := NewMeal("user1", "Lunch", mealTime)
+
+	if m.UserID != "user1" {
+		t.Errorf("expected userID user1, got %s", m.UserID)
+	}
+	if m.Name != "Lunch" {
+		t.Errorf("expected name Lunch, got %s", m.Name)
+	}
+	if !m.MealTime.Equal(mealTime) {
+		t.Errorf("expected mealTime %v, got %v", mealTime, m.MealTime)
+	}
+	if m.FiberRich || m.Dairy || m.Gluten {
+		t.Error("expected default boolean fields to be false")
+	}
+	if m.CreatedAt.IsZero() || m.UpdatedAt.IsZero() {
+		t.Error("expected timestamps to be set")
+	}
+}

--- a/backend/internal/domain/medication/model_test.go
+++ b/backend/internal/domain/medication/model_test.go
@@ -1,0 +1,34 @@
+package medication
+
+import (
+	"testing"
+)
+
+func TestNewMedicationDefaults(t *testing.T) {
+	m := NewMedication("user1", "Ibuprofen", "200mg", "daily")
+
+	if m.UserID != "user1" {
+		t.Errorf("expected userID user1, got %s", m.UserID)
+	}
+	if m.Name != "Ibuprofen" {
+		t.Errorf("expected name Ibuprofen, got %s", m.Name)
+	}
+	if m.Dosage != "200mg" {
+		t.Errorf("expected dosage 200mg, got %s", m.Dosage)
+	}
+	if m.Frequency != "daily" {
+		t.Errorf("expected frequency daily, got %s", m.Frequency)
+	}
+	if !m.IsActive {
+		t.Error("expected IsActive true by default")
+	}
+	if m.IsAsNeeded {
+		t.Error("expected IsAsNeeded false by default")
+	}
+	if len(m.SideEffects) != 0 {
+		t.Error("expected empty SideEffects slice")
+	}
+	if m.CreatedAt.IsZero() || m.UpdatedAt.IsZero() {
+		t.Error("expected timestamps to be set")
+	}
+}

--- a/backend/internal/domain/symptom/model_test.go
+++ b/backend/internal/domain/symptom/model_test.go
@@ -1,0 +1,30 @@
+package symptom
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewSymptomDefaults(t *testing.T) {
+	recorded := time.Now()
+	s := NewSymptom("user1", "Nausea", 5, recorded)
+
+	if s.UserID != "user1" {
+		t.Errorf("expected userID user1, got %s", s.UserID)
+	}
+	if s.Name != "Nausea" {
+		t.Errorf("expected name Nausea, got %s", s.Name)
+	}
+	if s.Severity != 5 {
+		t.Errorf("expected severity 5, got %d", s.Severity)
+	}
+	if !s.RecordedAt.Equal(recorded) {
+		t.Errorf("expected recordedAt %v, got %v", recorded, s.RecordedAt)
+	}
+	if len(s.Triggers) != 0 {
+		t.Error("expected empty Triggers slice")
+	}
+	if s.CreatedAt.IsZero() || s.UpdatedAt.IsZero() {
+		t.Error("expected timestamps to be set")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for Meal, Medication, and Symptom constructors

## Testing
- `go test ./internal/domain/... ./internal/validation -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68568131cd708320ae5b1722ab6cdcc0