### PR TITLE
🔧 refactor: avoid user variable shadowing

### DIFF
--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -40,7 +40,7 @@ func (a *JWTAuthService) Register(email, password, name string) (*user.User, str
 	if err != nil {
 		return nil, "", err
 	}
-	user := &user.User{
+	u := &user.User{
 		ID:        uuid.NewString(),
 		Email:     email,
 		Name:      name,
@@ -49,14 +49,14 @@ func (a *JWTAuthService) Register(email, password, name string) (*user.User, str
 	}
 
 	// Create user first
-	err = a.UserRepo.CreateUser(user)
+	err = a.UserRepo.CreateUser(u)
 	if err != nil {
 		return nil, "", err
 	}
 
 	// Create auth data - if this fails, we should clean up the user
 	auth := &user.UserAuth{
-		UserID:       user.ID,
+		UserID:       u.ID,
 		PasswordHash: string(hash),
 		Provider:     "local",
 		IsActive:     true,
@@ -66,15 +66,15 @@ func (a *JWTAuthService) Register(email, password, name string) (*user.User, str
 	err = a.UserRepo.CreateUserAuth(auth)
 	if err != nil {
 		// Clean up the user if auth creation fails
-		_ = a.UserRepo.DeleteUser(user.ID)
+		_ = a.UserRepo.DeleteUser(u.ID)
 		return nil, "", err
 	}
 
-	token, err := a.generateToken(user)
+	token, err := a.generateToken(u)
 	if err != nil {
 		return nil, "", err
 	}
-	return user, token, nil
+	return u, token, nil
 }
 
 func (a *JWTAuthService) Login(email, password string) (*user.User, string, error) {

--- a/backend/internal/service/two_factor.go
+++ b/backend/internal/service/two_factor.go
@@ -49,13 +49,13 @@ func (s *TwoFactorService) GenerateSecret(ctx context.Context, userID string) (*
 	}
 
 	// Get user for QR code generation
-	user, err := s.userRepo.GetUserByID(userID)
+	u, err := s.userRepo.GetUserByID(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
 
 	// Generate QR code URL
-	qrCodeURL := s.generateQRCodeURL(user.Email, secret)
+	qrCodeURL := s.generateQRCodeURL(u.Email, secret)
 
 	return &user.UserTwoFactorSetupResponse{
 		Secret:      secret,


### PR DESCRIPTION
## Summary
- rename local `user` variable to `u` in `JWTAuthService.Register`
- rename local `user` variable to `u` in `TwoFactorService.GenerateSecret`

## Testing
- `make test-backend` *(fails: `Makefile:72: *** missing separator.  Stop.`)*
- `go test -C backend ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_68568ab28304832095fa636531dab3eb