### PR TITLE
Add analytics service tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ format:
 	uv run ruff format ai-service
 
 format-backend:
-gofmt -s -w backend/**/*.go
+	gofmt -s -w backend/**/*.go
 format-ai:
-uv run ruff format ai-service
+	uv run ruff format ai-service
 
 clean:
-pnpm --filter @poo-tracker/frontend run clean
+	pnpm --filter @poo-tracker/frontend run clean

--- a/backend/internal/infrastructure/service/analytics/aggregator/data_aggregator_test.go
+++ b/backend/internal/infrastructure/service/analytics/aggregator/data_aggregator_test.go
@@ -1,0 +1,89 @@
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/bowelmovement"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/meal"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/medication"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/symptom"
+)
+
+func TestAggregateDailyData(t *testing.T) {
+	da := NewDataAggregator()
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 1)
+
+	movements := []bowelmovement.BowelMovement{
+		{RecordedAt: start, BristolType: 4, Pain: 2, Strain: 1, Satisfaction: 7},
+		{RecordedAt: end, BristolType: 5, Pain: 3, Strain: 1, Satisfaction: 6},
+	}
+	spicy := 3
+	meals := []meal.Meal{
+		{MealTime: start.Add(12 * time.Hour), Calories: 500, SpicyLevel: &spicy, Dairy: true},
+		{MealTime: end.Add(18 * time.Hour), Calories: 700, Gluten: true},
+	}
+	symptoms := []symptom.Symptom{
+		{RecordedAt: start.Add(10 * time.Hour), Severity: 4},
+	}
+	meds := []medication.Medication{
+		{Name: "med1", IsActive: true, StartDate: &start},
+	}
+
+	got := da.AggregateDailyData(movements, meals, symptoms, meds, start, end)
+	assert.Len(t, got, 2)
+
+	d1 := got[0]
+	assert.Equal(t, start, d1.Date)
+	assert.Equal(t, 1, d1.MealCount)
+	assert.Equal(t, 1, d1.SpicyMealCount)
+	assert.Equal(t, 1, d1.DairyMealCount)
+	assert.Equal(t, 1, d1.SymptomCount)
+}
+
+func TestCalculateAverage(t *testing.T) {
+	da := NewDataAggregator()
+	avg := da.CalculateAverage([]float64{1, 2, 3, 4})
+	assert.Equal(t, 2.5, avg)
+}
+
+func TestCalculateAverageSymptomSeverity(t *testing.T) {
+	da := NewDataAggregator()
+	symptoms := []symptom.Symptom{
+		{Severity: 3},
+		{Severity: 5},
+	}
+	avg := da.CalculateAverageSymptomSeverity(symptoms)
+	assert.Equal(t, 4.0, avg)
+}
+
+func TestGroupMealsByType(t *testing.T) {
+	da := NewDataAggregator()
+	spicy := 4
+	meals := []meal.Meal{
+		{Calories: 900},
+		{SpicyLevel: &spicy},
+		{Dairy: true},
+		{Gluten: true},
+		{Calories: 500, FiberRich: true},
+	}
+	groups := da.GroupMealsByType(meals)
+	assert.Len(t, groups["large"], 1)
+	assert.Len(t, groups["spicy"], 1)
+	assert.Len(t, groups["dairy"], 1)
+	assert.Len(t, groups["gluten"], 1)
+	assert.Len(t, groups["healthy"], 1)
+}
+
+func TestGetActiveMedicationPercentage(t *testing.T) {
+	da := NewDataAggregator()
+	meds := []medication.Medication{
+		{IsActive: true},
+		{IsActive: false},
+	}
+	pct := da.GetActiveMedicationPercentage(meds, 7)
+	assert.Equal(t, 50.0, pct)
+}

--- a/backend/internal/infrastructure/service/analytics/analyzer/trend_analyzer_stub.go
+++ b/backend/internal/infrastructure/service/analytics/analyzer/trend_analyzer_stub.go
@@ -1,4 +1,0 @@
-package analyzer
-
-// TrendAnalyzer is a minimal stub used for testing analytics helpers.
-type TrendAnalyzer struct{}

--- a/backend/internal/infrastructure/service/analytics/calculator/health_scores_test.go
+++ b/backend/internal/infrastructure/service/analytics/calculator/health_scores_test.go
@@ -1,0 +1,30 @@
+package calculator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kjanat/poo-tracker/backend/internal/domain/bowelmovement"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/meal"
+	"github.com/kjanat/poo-tracker/backend/internal/domain/symptom"
+)
+
+func TestHealthScoreCalculationSimple(t *testing.T) {
+	hds := NewHealthDataSummarizer()
+	hsc := NewHealthScoreCalculator()
+
+	day := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	movements := []bowelmovement.BowelMovement{{RecordedAt: day, BristolType: 4, Pain: 1, Strain: 1, Satisfaction: 7}}
+	meals := []meal.Meal{{MealTime: day.Add(8 * time.Hour), Calories: 500, FiberRich: true}}
+	symptoms := []symptom.Symptom{{RecordedAt: day.Add(2 * time.Hour), Severity: 2}}
+
+	bmSummary := hds.CalculateBowelMovementSummary(movements, 1)
+	mealSummary := hds.CalculateMealSummary(meals, 1)
+	symptomSummary := hds.CalculateSymptomSummary(symptoms, 1)
+	medSummary := hds.CalculateMedicationSummary(nil)
+
+	overall := hsc.CalculateOverallHealthScore(bmSummary, mealSummary, symptomSummary, medSummary)
+	assert.InEpsilon(t, 89.0, overall, 0.01)
+}

--- a/backend/internal/infrastructure/service/analytics/insights/insight_engine.go
+++ b/backend/internal/infrastructure/service/analytics/insights/insight_engine.go
@@ -62,7 +62,11 @@ func (ie *InsightEngine) GetRecommendationStrings(
 	recs := ie.GenerateRecommendations(bowelValues, mealValues, symptomValues)
 	var result []string
 	for _, rec := range recs {
-		result = append(result, rec.Message)
+		if rec.Description != "" {
+			result = append(result, rec.Description)
+		} else {
+			result = append(result, rec.Title)
+		}
 	}
 	return result
 }

--- a/backend/internal/infrastructure/service/analytics/insights/insight_engine_test.go
+++ b/backend/internal/infrastructure/service/analytics/insights/insight_engine_test.go
@@ -1,0 +1,25 @@
+package insights
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateRecommendationsEmptyData(t *testing.T) {
+	ie := NewInsightEngine()
+	recs := ie.GenerateRecommendations(nil, nil, nil)
+	assert.NotEmpty(t, recs)
+	for _, r := range recs {
+		assert.NotEmpty(t, r.Title)
+	}
+}
+
+func TestGetRecommendationStrings(t *testing.T) {
+	ie := NewInsightEngine()
+	msgs := ie.GetRecommendationStrings(nil, nil, nil)
+	assert.NotEmpty(t, msgs)
+	for _, m := range msgs {
+		assert.NotEmpty(t, m)
+	}
+}

--- a/backend/internal/infrastructure/service/analytics/shared/models.go
+++ b/backend/internal/infrastructure/service/analytics/shared/models.go
@@ -30,13 +30,22 @@ type DailyAggregation struct {
 
 // TrendPoint represents a single data point in a trend analysis
 type TrendPoint struct {
-	Time  time.Time `json:"time"`
+	Date  time.Time `json:"date"`
 	Value float64   `json:"value"`
+}
+
+// TrendLine represents a calculated data trend
+type TrendLine struct {
+	Name         string       `json:"name"`
+	Points       []TrendPoint `json:"points"`
+	Direction    string       `json:"direction"`
+	Slope        float64      `json:"slope"`
+	Confidence   float64      `json:"confidence"`
+	Significance string       `json:"significance"`
 }
 
 // Use domain analytics types for shared structures
 type CorrelationPair = analytics.Correlation
-type TrendLine = analytics.DataTrend
 type PatternMatch = analytics.Insight
 type HealthMetric = analytics.ScoreFactor
 

--- a/backend/internal/infrastructure/service/medication_service.go
+++ b/backend/internal/infrastructure/service/medication_service.go
@@ -145,8 +145,7 @@ func (s *MedicationService) Update(ctx context.Context, id string, input *medica
 	}
 
 	// Check if medication exists
-	existing, err := s.repo.GetByID(ctx, id)
-	if err != nil {
+	if _, err := s.repo.GetByID(ctx, id); err != nil {
 		return nil, err
 	}
 
@@ -202,10 +201,10 @@ func (s *MedicationService) Update(ctx context.Context, id string, input *medica
 	}
 
 	// Return updated medication
-    updated, err := s.repo.GetByID(ctx, id)
-    if err != nil {
-        return nil, fmt.Errorf("failed to retrieve updated medication: %w", err)
-    }
+	updated, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve updated medication: %w", err)
+	}
 
 	return updated, nil
 }


### PR DESCRIPTION
## Summary
- fix build issues in Makefile and medication service
- flesh out shared TrendLine model and adjust insight engine
- drop unused stub
- add unit tests for aggregator, calculator and insights packages

## Testing
- `make test-backend` *(fails: build errors in `backend/server`)*

------
https://chatgpt.com/codex/tasks/task_e_68568f907af48320a42f6b0f2ddce93f